### PR TITLE
🚀캐릭터가 곡선으로 이동할 수 있도록 해주는 베지어 커브 추가

### DIFF
--- a/src/constants/cameraPosition.ts
+++ b/src/constants/cameraPosition.ts
@@ -9,7 +9,7 @@ export const CAMERA_POSITIONS: Record<CameraKey, { position: Vector3; rotation: 
   },
   second: {
     position: new Vector3(-38.4, -21.6, 137.9),
-    rotation: new Euler(0.2, -1.1, 0.1),
+    rotation: new Euler(0.2, -1.4, 0.1),
   },
   third: {
     position: new Vector3(52.1, -20.5, 89.9),

--- a/src/constants/characterPosition.ts
+++ b/src/constants/characterPosition.ts
@@ -2,20 +2,25 @@ import { Vector3 } from 'three';
 
 export type CharacterKey = 'first' | 'second' | 'third' | 'fourth' | 'fifth';
 
-export const CHARACTER_POSITIONS: Record<CharacterKey, { position: Vector3 }> = {
+export const CHARACTER_POSITIONS: Record<CharacterKey, { position: Vector3; controlPoint: Vector3 }> = {
   first: {
-    position: new Vector3(-34.0, -28.0, 160.7),
+    position: new Vector3(-30.0, -28.0, 160.7),
+    controlPoint: new Vector3(-38.0, -28.0, 140.0),
   },
   second: {
-    position: new Vector3(-15, -28, 130.9),
+    position: new Vector3(-15, -28, 134.0),
+    controlPoint: new Vector3(60, -28, 144.0),
   },
   third: {
-    position: new Vector3(36, -28, 60),
+    position: new Vector3(37, -28, 50),
+    controlPoint: new Vector3(10, -28, 60),
   },
   fourth: {
     position: new Vector3(-14, -28, 50),
+    controlPoint: new Vector3(-37, -28, 25),
   },
   fifth: {
     position: new Vector3(-32, -28, -4),
+    controlPoint: new Vector3(-32, -28, -4),
   },
 };

--- a/src/hooks/use-scroll-driven-character-movement.ts
+++ b/src/hooks/use-scroll-driven-character-movement.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useScrollPosition } from '@/hooks/use-scroll-position.ts';
 import { CameraKey } from '@/constants/cameraPosition.ts';
 import { CHARACTER_POSITIONS } from '@/constants/characterPosition.ts';
-import { Vector3 } from 'three';
+import { Vector3, QuadraticBezierCurve3 } from 'three';
 
 interface SceneProps {
   sectionRatio: Record<string, number>;
@@ -18,10 +18,13 @@ export const useScrollDrivenCharacterMovement = ({ sectionRatio }: SceneProps) =
       const { startKey, endKey, sectionScrollFactor } = determineCameraKeysAndFactors(scrollFactor, sectionRatio);
 
       // <Important Logic>: Update camera position
-      const updatedCameraPosition = new Vector3()
-        .copy(CHARACTER_POSITIONS[startKey].position)
-        .lerp(CHARACTER_POSITIONS[endKey].position, sectionScrollFactor);
-      setCharacterPosition(updatedCameraPosition);
+      const curve = new QuadraticBezierCurve3(
+        CHARACTER_POSITIONS[startKey].position,
+        CHARACTER_POSITIONS[startKey].controlPoint,
+        CHARACTER_POSITIONS[endKey].position
+      );
+      const curvePosition = curve.getPoint(sectionScrollFactor);
+      setCharacterPosition(curvePosition);
     };
 
     window.addEventListener('scroll', handleScroll);


### PR DESCRIPTION
## 어떤 일에 대한 PR인가요?

기능 추가

## 변경사항에 대해 설명 해 주세요

- `useScrollDrivenCharacterMovement` 훅에서 직선이동이 아니라 항상 곡선으로 이동하도록 기능 추가
- 두 점사이의 거리를 이동시, 3차원 2차 베지어 곡선(quadratic bezier curve 3)를 이용하여 interpolation
- 직선으로 이동하고 싶다면, 두 점사이의 중점을 controlPoint로 설정시 가능

## PR 관련하여 추가로 알아야 할 사항이 있나요?

`미추구`시즌 때, 카메라 position 미세조정 필요할듯 함


## 🙏 셀프체크 🙏
( x 를 넣어주세요)
- [x] dev에서 빌드가 문제없이 작동하나요?
- [x] PR의 changes에 대해 한번 더 검토했나요?
- [x] 불필요한 console 등 디버깅 코드는 제거했나요?
- [x] commit 컨벤션을 맞췄나요?
    + 🔧(fix), ♻️(refactoring), 🎨(style), 📝(docs), 🚀(feat), 🧪(test), 📦(chore), 📌(release)



