### PR TITLE
🔧useCharacterRotation 에서 렌더링 너무 많이 일어나던 이슈 해결

### DIFF
--- a/src/hooks/use-character-rotation.ts
+++ b/src/hooks/use-character-rotation.ts
@@ -7,13 +7,16 @@ export const useCharacterRotation = (currentPosition: Vector3): Euler => {
   const [characterRotation, setCharacterRotation] = useState(new Euler(0, 0, 0));
 
   useEffect(() => {
-    if (!prevPosition.equals(currentPosition)) {
-      const direction = new Vector3().subVectors(currentPosition, prevPosition);
-      const newRotation = calculateRotationFromDirection(direction);
-      setCharacterRotation(newRotation);
-      setPrevPosition(currentPosition.clone());
+    if (!currentPosition || prevPosition.equals(currentPosition)) {
+      return;
     }
-  }, [currentPosition, prevPosition]);
+    const direction = new Vector3().subVectors(currentPosition, prevPosition);
+    const newRotation = calculateRotationFromDirection(direction);
+    setCharacterRotation(newRotation);
+    setPrevPosition(currentPosition.clone());
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentPosition]);
 
   return characterRotation;
 };


### PR DESCRIPTION
## 어떤 일에 대한 PR인가요?

이슈 해결

## 변경사항에 대해 설명 해 주세요

스크롤을 최 하단까지 내릴시, prevPosition과 currentPosition이 같아서 너무 렌더링이 많이되던 이슈 해결

<img width="740" alt="image" src="https://github.com/5Duck-Lab/serengeti/assets/63194662/72a90b4c-88eb-4e14-89e8-f5928cdbb108">


## PR 관련하여 추가로 알아야 할 사항이 있나요?
x


## 🙏 셀프체크 🙏
( x 를 넣어주세요)
- [x] dev에서 빌드가 문제없이 작동하나요?
- [x] PR의 changes에 대해 한번 더 검토했나요?
- [x] 불필요한 console 등 디버깅 코드는 제거했나요?
- [x] commit 컨벤션을 맞췄나요?
    + 🔧(fix), ♻️(refactoring), 🎨(style), 📝(docs), 🚀(feat), 🧪(test), 📦(chore), 📌(release)



